### PR TITLE
Add docker image pruning

### DIFF
--- a/scripts/docker-prune.sh
+++ b/scripts/docker-prune.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Prune docker images
+
+### 1. Prune dangling images
+echo "Prune dangling images"
+docker image prune --force
+
+### 2. Remove old warm-db images
+# Retention period threshold for image pruning
+# We are using format "+%F %T %z %Z" - because it's same for Docker "{{.CreatedAt}}"
+THRESHOLD_TIME=$(date --utc --date="-7 days" "+%F %T %z %Z")
+
+# First function param should be repository name for warm images (fe. warm-db, warm-thunder-php, etc.)
+function prune_warm_images() {
+    while IFS= read -r IMAGE_LS_LINE; do
+        # Get image ID and create time from "docker image ls" command
+        IFS=' ' read -r IMAGE_ID CREATE_TIME <<<"${IMAGE_LS_LINE}"
+
+        # Remove image if crate time is older then retention period threshold
+        if [[ "${THRESHOLD_TIME}" > "${CREATE_TIME}" ]]; then
+            echo "Removing image: ${IMAGE_ID}"
+
+            # Referenced images will not be removed.
+            # For example: if image "repo1:tag1" reference image "repo2:tag2", then it's not possible to remove "repo2:tag2"
+            docker image rm "${IMAGE_ID}"
+        fi
+    done <<<"$(docker image ls "${1}" --format "{{.ID}} {{.CreatedAt}}")"
+}
+
+prune_warm_images "warm-db"
+prune_warm_images "warm-thunder-php"
+prune_warm_images "burda/thunder-performance"

--- a/scripts/server-init.sh
+++ b/scripts/server-init.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 #
 # Init server script
@@ -16,7 +15,7 @@ sudo apt-get install --yes docker-ce
 
 # Add user to docker group
 sudo groupadd docker
-sudo usermod -aG docker $USER
+sudo usermod -aG docker "${USER}"
 
 # Install docker-compose
 sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -29,7 +28,7 @@ nvm install --lts node
 
 # Checkout repository
 git clone https://github.com/thunder/thunder-performance-task-manager.git "${DEPLOYMENT_DIR}"
-cd "${DEPLOYMENT_DIR}"
+cd "${DEPLOYMENT_DIR}" || exit
 
 # Add certificates
 openssl req -nodes -new -x509 -keyout "${DEPLOYMENT_DIR}/server.key" -out "${DEPLOYMENT_DIR}/server.cert" -subj "/C=DE/ST=Bavaria/L=Munich/O=Thunder/OU=Thunder"
@@ -45,7 +44,7 @@ sudo systemctl enable thunder-ptm-service
 cp "${DEPLOYMENT_DIR}/.env.example" "${DEPLOYMENT_DIR}/.env"
 
 # Generate TOKEN
-echo "EXPRESS_TOKEN=$(openssl rand -hex 64)" >> "${DEPLOYMENT_DIR}/.env"
+echo "EXPRESS_TOKEN=$(openssl rand -hex 64)" >>"${DEPLOYMENT_DIR}/.env"
 
 # Build project
 npm install --prefix "${DEPLOYMENT_DIR}"

--- a/warmer/build.sh
+++ b/warmer/build.sh
@@ -90,7 +90,5 @@ docker-compose --file "${DOCKER_COMPOSE_FILE}" stop
 docker commit "warmer-db-${BRANCH_TAG}" "warm-db:${BRANCH_TAG}"
 docker commit "warmer-thunder-php-${BRANCH_TAG}" "warm-thunder-php:${BRANCH_TAG}"
 
-# TODO: delete $THUNDER_PERFORMANCE_IMAGE_NAME docker image, because it's not needed anymore
-
 # Remove all docker-composer containers and volumes
 docker-compose --file "${DOCKER_COMPOSE_FILE}" down --volumes


### PR DESCRIPTION
Changes in `server-init.sh` are not relevant, that script is not in use anyway. It's just small `shellcheck` cleanup.

Removing of `burda/thunder-performance` images in `warmer/build.sh` is not possible, because newly created `warm-thunder-php` image will have reference on `burda/thunder-performance` image.