### PR TITLE
Added graceful termination of Worker

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ const config = {
     // 3 days
     defaultExpire: 259200,
     // Fetch time out in seconds. 0 = infinite
-    fetchTimeout: 0,
+    fetchTimeout: 60,
   },
   redis: {
     queueName: 'thunder-ptm-queue',

--- a/queue.js
+++ b/queue.js
@@ -103,7 +103,7 @@ const fetch = () => {
   // and Job Data - STRING
     .then((result) => {
       if (!result) {
-        return Promise.reject(new Error('Fetch wait did timed out.'));
+        return Promise.reject(new Error('Fetch wait timed out.'));
       }
 
       const branchTag = result[1];

--- a/queue.js
+++ b/queue.js
@@ -101,7 +101,6 @@ const fetch = () => {
     .bzpopmin(config.redis.queueName, config.queue.fetchTimeout)
   // 2. Get TTL Holder for branch - STRING
   // and Job Data - STRING
-  /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }] */
     .then((result) => {
       if (!result) {
         return Promise.reject(new Error('Fetch wait did timed out.'));

--- a/queue.js
+++ b/queue.js
@@ -117,9 +117,8 @@ const fetch = () => {
       if (!ttlBranchTag) {
         redis.del(jobData.branchTag);
 
-        return Promise.reject(
-          new Error(`Job TTL has expired for branchTag: ${jobData.branchTag}.`),
-        );
+        // Returns new Promise for fetch
+        return loopResolver();
       }
 
       return new Promise((resolve) => {

--- a/scripts/thunder-ptm-worker.service
+++ b/scripts/thunder-ptm-worker.service
@@ -6,6 +6,7 @@ After=network.target
 Restart=always
 User=ubuntu
 Group=ubuntu
+TimeoutStopSec=1200
 Environment=NODE_ENV=production
 Environment=NODE_VERSION=node
 WorkingDirectory=/home/ubuntu/thunder-ptm

--- a/worker.js
+++ b/worker.js
@@ -11,7 +11,7 @@ const { config } = require('./config');
 let shouldTerminate = false;
 process.on('SIGTERM', () => {
   console.log('Worker received SIGTERM!');
-  console.log('It can take several minutes before worker terminates.');
+  console.log('It can take several minutes before the worker terminates.');
 
   shouldTerminate = true;
 });

--- a/worker.js
+++ b/worker.js
@@ -7,6 +7,15 @@ require('dotenv').config();
 // Get config.json
 const { config } = require('./config');
 
+// Graceful termination flag and handling of system signal
+let shouldTerminate = false;
+process.on('SIGTERM', () => {
+  console.log('Worker received SIGTERM!');
+  console.log('It can take several minutes before worker terminates.');
+
+  shouldTerminate = true;
+});
+
 // Build command for different job types
 function getCommand(jobData) {
   switch (jobData.type) {
@@ -54,8 +63,12 @@ function execCommand(command) {
 }
 
 function loop() {
-  console.log('Worker waiting for job...');
+  if (shouldTerminate) {
+    console.log('Worker stopped!');
+    process.exit();
+  }
 
+  console.log('Worker waiting for job...');
   queue
     .fetch()
     .then(async (jobData) => {


### PR DESCRIPTION
Following changes are made:

`config.js` - changed `fetchTimeout` to have limited time, because if queue is empty, worker could wait infinite time and never exit properly.
`queue.js` - changed `fetch` to throw error when something fails instead of try fetch again. So that caller can handle it, otherwise it could stay in infinite loop if queue is empty.
`thunder-ptm-worker.service` - changed timeout value, so that worker has more time to exit, before it's KILLED! Docs here: [https://www.freedesktop.org/software/systemd/man/systemd.service.html#TimeoutStopSec=](https://www.freedesktop.org/software/systemd/man/systemd.service.html#TimeoutStopSec=)
`worker.js` - added handling of `SIGTERM`